### PR TITLE
xsm-instruction-cycle typo fix

### DIFF
--- a/Tutorials/xsm-instruction-cycle.html
+++ b/Tutorials/xsm-instruction-cycle.html
@@ -6,7 +6,7 @@
     ================================================== -->
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-     <title>XSM Instruction Exceution Cycle</title>
+     <title>XSM Instruction Execution Cycle</title>
 
     <!-- Mobile Specific Metas
     ================================================== -->


### PR DESCRIPTION
Fix Spelling : Instruction Exceution Cycle -> Instruction Execution Cycle