### PR TITLE
Fix get code page description

### DIFF
--- a/os_modules/Module_2.html
+++ b/os_modules/Module_2.html
@@ -265,7 +265,7 @@ Note : Do not clear the contents of the page. A page may be shared by multiple p
 </pre>
 
  <h3> Get Code Page </h3>
- <i> <b>Description </b></i>: Loads a single code page to memory given the block number of the page in the disk. It takes the block number and PID as an argument.<br><br>
+ <i> <b>Description </b></i>: Loads a single code page to memory given the block number of the page in the disk. It takes the block number as an argument.<br><br>
 
 
 <pre>


### PR DESCRIPTION
Get code page takes only block number as argument.