### PR TITLE
Remove invalid character which causes layout issues

### DIFF
--- a/os_modules/Module_0.html
+++ b/os_modules/Module_0.html
@@ -51,11 +51,11 @@
  <style type="text/css">
    
    pre{
-    font-family: Times new Roman; 
-    font-size: 15px;"
+    font-family: "Times new Roman"; 
+    font-size: 15px;
    }
 
- </style>>   
+ </style>
 
   </head>
   <body> 

--- a/os_modules/Module_1.html
+++ b/os_modules/Module_1.html
@@ -48,14 +48,14 @@
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
   
- <style type="text/css">
+    <style type="text/css">
    
-   pre{
-    font-family: Times new Roman; 
-    font-size: 15px;"
-   }
-
- </style>>   
+      pre{
+       font-family: "Times new Roman"; 
+       font-size: 15px;
+      }
+   
+    </style> 
 
   </head>
   <body> 

--- a/os_modules/Module_2.html
+++ b/os_modules/Module_2.html
@@ -48,14 +48,14 @@
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
   
- <style type="text/css">
+    <style type="text/css">
    
-   pre{
-    font-family: Times new Roman; 
-    font-size: 15px;"
-   }
-
- </style>>   
+      pre{
+       font-family: "Times new Roman"; 
+       font-size: 15px;
+      }
+   
+    </style>   
 
   </head>
   <body> 

--- a/os_modules/Module_3.html
+++ b/os_modules/Module_3.html
@@ -48,14 +48,14 @@
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
   
- <style type="text/css">
+    <style type="text/css">
    
-   pre{
-    font-family: Times new Roman; 
-    font-size: 15px;"
-   }
-
- </style>>   
+      pre{
+       font-family: "Times new Roman"; 
+       font-size: 15px;
+      }
+   
+    </style>   
 
   </head>
   <body> 

--- a/os_modules/Module_4.html
+++ b/os_modules/Module_4.html
@@ -48,14 +48,14 @@
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
   
- <style type="text/css">
+    <style type="text/css">
    
-   pre{
-    font-family: Times new Roman; 
-    font-size: 15px;"
-   }
-
- </style>>   
+      pre{
+       font-family: "Times new Roman"; 
+       font-size: 15px;
+      }
+   
+    </style>   
 
   </head>
   <body> 

--- a/os_modules/Module_5.html
+++ b/os_modules/Module_5.html
@@ -48,14 +48,14 @@
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
   
- <style type="text/css">
+    <style type="text/css">
    
-   pre{
-    font-family: Times new Roman; 
-    font-size: 15px;"
-   }
-
- </style>>   
+      pre{
+       font-family: "Times new Roman"; 
+       font-size: 15px;
+      }
+   
+    </style>  
 
   </head>
   <body> 

--- a/os_modules/Module_6.html
+++ b/os_modules/Module_6.html
@@ -48,14 +48,14 @@
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
   
- <style type="text/css">
+    <style type="text/css">
    
-   pre{
-    font-family: Times new Roman; 
-    font-size: 15px;
-   }
-
- </style>>   
+      pre{
+       font-family: "Times new Roman"; 
+       font-size: 15px;
+      }
+   
+    </style>  
 
   </head>
   <body> 

--- a/os_modules/Module_8.html
+++ b/os_modules/Module_8.html
@@ -50,11 +50,13 @@
     <![endif]-->
 
     <style type="text/css">
-        pre {
-            font-family: Times new Roman;
-            font-size: 15px;
+   
+        pre{
+         font-family: "Times new Roman"; 
+         font-size: 15px;
         }
-    </style>>
+     
+      </style>
 
 </head>
 


### PR DESCRIPTION
Fixes the following layout bug , caused by having an extra `>` character.

![image](https://user-images.githubusercontent.com/3852827/97181665-8c01fe80-17c1-11eb-8a8e-9ddc4bc16324.png)
